### PR TITLE
Add directional spectator switching via arrows and screen taps

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -473,7 +473,7 @@ export class UI {
         this.spectatorEl.innerHTML = `
             <div>SPECTATING</div>
             <div id="spectator-name" style="font-size: 20px; color: #00E5FF; margin-top: 5px;"></div>
-            <div style="font-size: 10px; color: #666; margin-top: 10px;">[TAB] NEXT PLAYER</div>
+            <div style="font-size: 10px; color: #666; margin-top: 10px;">[←/→ OR TAP SIDES] NEXT PLAYER</div>
         `;
         this.container.appendChild(this.spectatorEl);
 


### PR DESCRIPTION
### Motivation
- Improve spectator UX so when a player dies in multiplayer they can quickly switch which alive player the camera follows using familiar left/right controls or by tapping the screen halves. 
- Provide both keyboard and pointer/touch controls while ensuring normal gameplay controls remain unchanged. 
- Keep behavior gated to spectator mode to avoid regressions during active play.

### Description
- Added a canvas `pointerdown` listener and implemented `handleSpectatorPointer` in `src/game.ts` to switch spectated players by tapping/clicking the left or right half of the screen. 
- Updated keyboard handling in `handleKey` to intercept `ArrowLeft`/`ArrowRight` and `A`/`D` (and preserve `Tab`) when `GameState.SPECTATING`, calling `spectateNextPlayer` with direction. 
- Changed `spectateNextPlayer` to accept a `direction: 1 | -1` parameter and perform wrap-around selection across alive remote players without affecting normal gameplay input. 
- Updated spectator HUD text in `src/ui.ts` to `"[←/→ OR TAP SIDES] NEXT PLAYER"` to reflect the new controls.

### Testing
- `npx tsc --noEmit` was run and reported a failure due to pre-existing implicit `any` errors in `src/net/apple-sync.ts`, which are unrelated to these changes. 
- `npx vite build` was run and completed successfully. 
- The dev server was started and a headless browser screenshot of the menu was captured to validate the app loads successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698484a049b883279a1b5b12dccb4c94)